### PR TITLE
Use correct casing for loading JS resources

### DIFF
--- a/src/assetbundles/EventsAsset.php
+++ b/src/assetbundles/EventsAsset.php
@@ -23,7 +23,7 @@ class EventsAsset extends AssetBundle
         ];
 
         $this->js = [
-            'js/events.js',
+            'js/Events.js',
         ];
 
         parent::init();


### PR DESCRIPTION
AFAIK, on Mac case-sensitivity isn't an issue, however running on any *nix system, the `js/events.js` file will return a 500 error as the actual file name is `js/Events.js`.