### PR TITLE
Fix error with project config rebuild

### DIFF
--- a/src/Events.php
+++ b/src/Events.php
@@ -13,6 +13,7 @@ use verbb\events\variables\EventsVariable;
 
 use Craft;
 use craft\base\Plugin;
+use craft\events\RebuildConfigEvent;
 use craft\events\RegisterComponentTypesEvent;
 use craft\events\RegisterUserPermissionsEvent;
 use craft\events\RegisterUrlRulesEvent;


### PR DESCRIPTION
Fixes error that occurs when trying a project config rebuild:
`Argument 1 passed to verbb\events\Events::verbb\events\{closure}() must be an instance of verbb\events\RebuildConfigEvent, instance of craft\events\RebuildConfigEvent given`