### PR TITLE
Purchased Ticket updates

### DIFF
--- a/src/controllers/PurchasedTicketsController.php
+++ b/src/controllers/PurchasedTicketsController.php
@@ -129,5 +129,41 @@ class PurchasedTicketsController extends Controller
         Craft::$app->getSession()->setNotice(Craft::t('events', 'Purchased ticket deleted.'));
 
         return $this->redirectToPostedUrl($purchasedTicket);
-    }
+	}
+	
+	public function actionCheckin()
+	{
+		$this->requirePostRequest();
+
+		$purchasedTicketId = Craft::$app->getRequest()->getRequiredParam('id');
+		$purchasedTicket = PurchasedTicket::findOne($purchasedTicketId);
+		
+		if (!$purchasedTicket) {
+            throw new Exception(Craft::t('events', 'No purchased ticket exists with the ID “{id}”.', ['id' => $purchasedTicketId]));
+        }
+
+		Events::$plugin->getPurchasedTickets()->checkInPurchasedTicket($purchasedTicket);
+
+		Craft::$app->getSession()->setNotice(Craft::t('events', 'Ticket checked in.'));
+
+        return $this->redirectToPostedUrl($purchasedTicket);
+	}
+
+	public function actionUncheckin()
+	{
+		$this->requirePostRequest();
+
+		$purchasedTicketId = Craft::$app->getRequest()->getRequiredParam('id');
+		$purchasedTicket = PurchasedTicket::findOne($purchasedTicketId);
+		
+		if (!$purchasedTicket) {
+            throw new Exception(Craft::t('events', 'No purchased ticket exists with the ID “{id}”.', ['id' => $purchasedTicketId]));
+        }
+
+		Events::$plugin->getPurchasedTickets()->unCheckInPurchasedTicket($purchasedTicket);
+
+		Craft::$app->getSession()->setNotice(Craft::t('events', 'Ticket un-checked in.'));
+
+        return $this->redirectToPostedUrl($purchasedTicket);
+	}
 }

--- a/src/controllers/PurchasedTicketsController.php
+++ b/src/controllers/PurchasedTicketsController.php
@@ -59,7 +59,9 @@ class PurchasedTicketsController extends Controller
             $variables['title'] = $variables['purchasedTicket']->ticketSku;
         } else {
             $variables['title'] = Craft::t('events', 'Create a Purchased Ticket');
-        }
+		}
+		
+		$variables['fieldLayout'] = $variables['purchasedTicket']->getFieldLayout();
         
         return $this->renderTemplate('events/purchased-tickets/_edit', $variables);
     }

--- a/src/elements/Ticket.php
+++ b/src/elements/Ticket.php
@@ -291,11 +291,11 @@ class Ticket extends Purchasable
 
     public function getIsEditable(): bool
     {
-        $event = $this->getEvent();
+        /*$event = $this->getEvent();
 
         if ($event) {
             return $event->getIsEditable();
-        }
+        }*/
 
         return false;
     }

--- a/src/elements/Ticket.php
+++ b/src/elements/Ticket.php
@@ -472,7 +472,9 @@ class Ticket extends Purchasable
             $purchasedTicket->ticketId = $this->id;
             $purchasedTicket->orderId = $order->id;
             $purchasedTicket->lineItemId = $lineItem->id;
-            $purchasedTicket->ticketSku = TicketHelper::generateTicketSKU();
+			$purchasedTicket->ticketSku = TicketHelper::generateTicketSKU();
+			
+			$purchasedTicket->setFieldValues($this->getFieldValues());
 
             $elementsService->saveElement($purchasedTicket, false);
         }

--- a/src/elements/actions/Checkin.php
+++ b/src/elements/actions/Checkin.php
@@ -1,0 +1,38 @@
+<?php
+namespace verbb\events\elements\actions;
+
+use verbb\events\Events;
+
+use Craft;
+use craft\base\Element;
+use craft\base\ElementAction;
+use craft\elements\db\ElementQueryInterface;
+
+class Checkin extends ElementAction
+{
+    // Public Methods
+	// =========================================================================
+	
+	public function getTriggerLabel(): string
+    {
+        return Craft::t('events', 'Check in');
+	}
+	
+    /**
+     * @inheritdoc
+     */
+    public function performAction(ElementQueryInterface $query = null): bool
+    {
+        if (!$query) {
+            return false;
+        }
+
+        foreach ($query->all() as $purchasedTicket) {
+            Events::$plugin->getPurchasedTickets()->checkInPurchasedTicket($purchasedTicket);
+        }
+
+        $this->setMessage(Craft::t('events', 'Tickets checked in'));
+
+        return true;
+    }
+}

--- a/src/services/PurchasedTickets.php
+++ b/src/services/PurchasedTickets.php
@@ -34,5 +34,17 @@ class PurchasedTickets extends Component
         $record->checkedInDate = $purchasedTicket->checkedInDate;
 
         $record->save(false);
+	}
+	
+	public function unCheckInPurchasedTicket(PurchasedTicket $purchasedTicket)
+    {
+        $purchasedTicket->checkedIn = false;
+        $purchasedTicket->checkedInDate = null;
+
+        $record = PurchasedTicketRecord::findOne($purchasedTicket->id);
+        $record->checkedIn = $purchasedTicket->checkedIn;
+        $record->checkedInDate = $purchasedTicket->checkedInDate;
+
+        $record->save(false);
     }
 }

--- a/src/templates/purchased-tickets/_edit.html
+++ b/src/templates/purchased-tickets/_edit.html
@@ -10,6 +10,16 @@
 {% set selectedSubnavItem = 'purchasedTickets' %}
 {% set element = purchasedTicket %}
 
+{% set selectedTab = 'ticketDetailsTab' %}
+{% set tabs = {
+	ticketDetailsTab: { label: 'Details' | t('events'), url: '#ticketDetailsTab' },
+} %}
+{% for tab in fieldLayout.getTabs() %}
+	{% set tabs = tabs|merge({
+		("tab"~loop.index) : { label: tab.name | t('events'), url: '#tab'~loop.index }
+	}) %}
+{% endfor %}
+
 {% block actionButton %}
     <div id="save-btn-container" class="btngroup submit">
         <input type="submit" class="btn submit" value="{{ 'Save' | t('app', { type: element.displayName() }) }}">
@@ -44,6 +54,7 @@
 <input type="hidden" name="action" value="events/purchased-tickets/save">
 <input type="hidden" name="id" value="{{ purchasedTicket.id }}">
 
+<div id="ticketDetailsTab">
 {{ forms.textField({
     first: true,
     label: 'Ticket SKU' | t('events'),
@@ -64,6 +75,16 @@
 </p>
 
 <img width="150px" src="{{ purchasedTicket.qrCode }}" />
+</div>
+
+{% for tab in fieldLayout.getTabs() %}
+    <div id="tab{{ loop.index }}" class="hidden">
+        {% include "_includes/fields" with {
+            fields: tab.getFields(),
+            element: purchasedTicket,
+        } only %}
+    </div>
+{% endfor %}
 
 {% endblock %}
 
@@ -109,7 +130,18 @@
     <h5>{{ 'Checked In' | t('events') }}</h5>
 
     <p>
-        <span class="status {{ purchasedTicket.checkedIn ? 'live' : 'disabled' }}"></span>
+        <span class="status {{ purchasedTicket.checkedIn ? 'live' : 'disabled' }}"></span> 
+		{% if purchasedTicket.checkedIn %}
+			<a class="formsubmit btn small" data-action="events/purchased-tickets/uncheckin"
+				data-redirect="{{ 'events/purchased-tickets' | hash }}">
+				{{ 'Un-Check in' | t('events') }}
+			</a>
+		{% else %}
+			<a class="formsubmit btn small" data-action="events/purchased-tickets/checkin"
+				data-redirect="{{ 'events/purchased-tickets' | hash }}">
+				{{ 'Check in' | t('events') }}
+			</a>
+		{% endif %}
     </p>
 
     <h5>{{ 'Checked In Date' | t('events') }}</h5>


### PR DESCRIPTION
there are a few improvements here...

- Purchased tickets now have custom fields that are inherited from the ticket. (#42)
- Custom fields on the purchased ticket can be viewed and edited on the details page. (#42)
- manual checkin button added to the purchased ticket detail page. (#47)
- manual uncheck button if ticket is already checked in. (#47)
- checkin action added to the purchased tickets element index. (#47)
- the element index sources are grouped by event type.
- if logged in user has manage purchasedTickets permission then will redirect to purchased tickets element index after check in via url or qr code. (#48)
- added permissions check on check in controller to see if allowed to check in