### PR TITLE
When generating purchased tickets use serialized field values so thar elements etc get regenerated

### DIFF
--- a/src/elements/Ticket.php
+++ b/src/elements/Ticket.php
@@ -479,7 +479,7 @@ class Ticket extends Purchasable
 			$purchasedTicket->ticketSku = TicketHelper::generateTicketSKU();
 			
             // Set the field values from the ticket (handle defaults, and values set on the ticket)
-			$purchasedTicket->setFieldValues($this->getFieldValues());
+			$purchasedTicket->setFieldValues($this->getSerializedFieldValues());
 
             // But also allow overriding through the line item options
             foreach ($lineItem->options as $option => $value) {


### PR DESCRIPTION
I have a super table field set on my tickets that is populated with session dates, when an order goes through those super table blocks are _moved_ over to the purchased ticket rather than being replicated as fresh blocks.

This change fixes that, but I have no idea what other impact there may be!