### PR TITLE
Adds two hooks to the Event CP edit page

### DIFF
--- a/src/templates/events/_edit.html
+++ b/src/templates/events/_edit.html
@@ -63,6 +63,8 @@
 {% endblock %}
 
 {% block actionButton %}
+    {% hook "events.edit.actionbutton" %}
+
     <div class="btngroup">
         <input type="submit" class="btn submit" value="{{ 'Save' | t('app') }}">
         <div class="btn submit menubtn"></div>

--- a/src/templates/events/_edit.html
+++ b/src/templates/events/_edit.html
@@ -347,4 +347,6 @@
             </div>
         </div>
     {% endif %}
+
+    {% hook "events.edit.details" %}
 {% endblock %}


### PR DESCRIPTION
This PR adds the following two events to the Event CP edit page to allow plugins and modules to modify the page:

- `events.edit.actionbutton` renders before the save action button
- `events.edit.details` renders at the very end of the sidebar panels