### PR TITLE
jsvrcek/ics dependency updated for php 8.0 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "craftcms/commerce": "^3.0.0",
         "verbb/base": "^1.0.2",
         "endroid/qr-code": "^2.0.0",
-        "jsvrcek/ics": "^0.7.0"
+        "jsvrcek/ics": "^0.8.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
When installing the plugin to a PHP8 site I'm seeing the following.

```
Composer output: Loading composer repositories with package information
Info from https://repo.packagist.org: [37;44m#StandWith[30;43mUkraine[0m
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

Problem 1
- verbb/events 1.4.20 requires jsvrcek/ics ^0.7.0 -> satisfiable by jsvrcek/ics[0.7].
- jsvrcek/ics 0.7 requires php ^5.4 || ^7.0 -> your php version (8.0; overridden via config.platform, actual: 8.0.16) does not satisfy that requirement.
- Root composer.json requires verbb/events 1.4.20 -> satisfiable by verbb/events[1.4.20].

Running update with --no-dev does not mean require-dev is ignored, it just means the packages will not be installed. If dev requirements are blocking the update you have to resolve those problems.
```





**Steps to reproduce**
1. Go to Admin > Plugin Store > Events
2. Click Try

**Additional info**
- Plugin version: 1.4.20
- Craft version: 3.7.37
- Multi-site: No

The jsvrek/ics dependency has a new release which bumps the supported php version in the composer file.
More details here https://github.com/jasvrcek/ICS/issues/59  

I also see it fixed in the Craft 4 branch.

Thanks
