### PR TITLE
Add error state to the Date/Time tab if a field has errors.

### DIFF
--- a/src/controllers/EventsController.php
+++ b/src/controllers/EventsController.php
@@ -237,9 +237,16 @@ class EventsController extends Controller
             ];
         }
 
+        $hasErrors = false;
+
+        if($event->hasErrors('startDate') || $event->hasErrors('endDate') || $event->hasErrors('allDay')){
+            $hasErrors = true;
+        }
+
         $variables['tabs']['tab-dates-container'] = [
             'label' => Craft::t('events', 'Dates/Times'),
             'url' => '#tab-dates-container',
+            'class' => $hasErrors ? 'error' : null,
         ];
 
         $hasErrors = false;


### PR DESCRIPTION
[v1.4.23](https://github.com/verbb/events/tree/1.4.23) added Date/Time validation but didn't include adding the error state to the tab.
This PR adds the error state if one of the fields has an error.