### PR TITLE
Adds check for stock to is available

### DIFF
--- a/src/elements/Ticket.php
+++ b/src/elements/Ticket.php
@@ -303,6 +303,10 @@ class Ticket extends Purchasable
     public function getIsAvailable(): bool
     {
         if ($type = $this->getType()) {
+            if (!$this->getStock()) {
+                return false; 
+            }
+
             $currentTime = DateTimeHelper::currentTimeStamp();
 
             if ($type->availableFrom) {


### PR DESCRIPTION
The backend enforcement of https://github.com/verbb/events/issues/158#issuecomment-2475202499 seems to be working for me now with v3.0.3, but `getIsAvailable()` is still always `true` regardless of the capacity.

I believe it’s fixed with this PR? Thanks!