### PR TITLE
Bugfix: Event Capacity

### DIFF
--- a/src/helpers/EventHelper.php
+++ b/src/helpers/EventHelper.php
@@ -84,7 +84,13 @@ class EventHelper
         $event->enabledForSite = (bool)$request->getParam('enabledForSite', $event->enabledForSite);
 
         $event->allDay = (bool)$request->getParam('allDay');
-        $event->capacity = (int)$request->getParam('capacity');
+
+        // allow capacity to be set to null - otherwise, force int
+        $capacity = $request->getParam('capacity');
+        if ($capacity !== null) {
+            $capacity = (int)$capacity;
+        }
+        $event->capacity = $capacity;
 
         if (($startDate = $request->getParam('startDate')) !== null) {
             $event->startDate = DateTimeHelper::toDateTime($startDate) ?: null;


### PR DESCRIPTION
A recent update to this plugin forced a saved event with null capacity to have capacity = 0. This pull request fixes the bug, allowing a null (unlimited) capacity, while forcing any non-null value to be an int.