### PR TITLE
Fixed a Mutex exception that could occur in certain scenarios when retrieving a cart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- Fixed a Mutex exception that could occur in certain scenarios when retrieving a cart.
+
 ## 2.0.11 - 2025-09-02
 
 ### Added

--- a/src/elements/Ticket.php
+++ b/src/elements/Ticket.php
@@ -436,7 +436,7 @@ class Ticket extends Purchasable
     {
         $errors = [];
 
-        $cart = Commerce::getInstance()->getCarts()->getCart();
+        $cart = $lineItem->getOrder();
 
         // Get the total number of tickets for the same event and ticket type. We can't just rely on quantity
         // of this line item as there could be tickets with unique options set, which are separate line items.


### PR DESCRIPTION
Grab the existing cart/order based on the lineitem, rather than trying to retrieve an existing one based on the current session.

This prevents a scenario in which a mutex exception occurs after logging in when trying to restore a user's cart.

Can be merged into the Craft 5 compatible branch, as the issue exists there, too.