### PR TITLE
Fix SQL syntax error in Events 3 migration with quoted column names

### DIFF
--- a/src/migrations/m240921_000000_events3.php
+++ b/src/migrations/m240921_000000_events3.php
@@ -494,13 +494,13 @@ class m240921_000000_events3 extends Migration
                     }
 
                     $legacyTicketId = (new Query())
-                        ->select(['"legacyTicketId"'])
+                        ->select(['legacyTicketId'])
                         ->from('{{%events_ticket_types}}')
                         ->where(['id' => $ticketType->id])
                         ->scalar();
 
                     $legacyTicketTypeId = (new Query())
-                        ->select(['"typeId"'])
+                        ->select(['typeId'])
                         ->from('{{%events_legacy_tickets}}')
                         ->where(['id' => $legacyTicketId])
                         ->scalar();


### PR DESCRIPTION
This PR fixes a critical bug in the m240921_000000_events3 migration that causes SQL errors during the Craft 5 upgrade process.

### Problem
The migration contains incorrect SQL syntax where column names are wrapped in double quotes as string literals instead of being used as column identifiers:
```
$legacyTicketId = (new Query())
    ->select(['"legacyTicketId"'])  // ❌ Incorrect - treats as string literal
    ->from('{{%events_ticket_types}}')
    ->where(['id' => $ticketType->id])
    ->scalar();
```
This results in the following SQL error, after 30 minutes of migration:

```
SQLSTATE[42S22]: Column not found: 1054 Unknown column '"legacyTicketId"' in 'field list'
The SQL being executed was: SELECT `"legacyTicketId"` FROM `events_ticket_types` WHERE `id`=[aRandomID]
```

MySQL interprets the double quotes as part of the column name itself (looking for a column literally named "legacyTicketId" with quotes), rather than the column legacyTicketId.

### Solution
Remove the double quotes around column names in the ->select() statements:

```
$legacyTicketId = (new Query())
    ->select(['legacyTicketId'])  // ✅ Correct
    ->from('{{%events_ticket_types}}')
    ->where(['id' => $ticketType->id])
    ->scalar();

```
### Impact
This bug prevents the Events 3 migration from completing successfully when upgrading from Events 2 to Events 3 on Craft 5, potentially affecting all users performing this upgrade with large datasets.

### Testing
Tested on MySQL 8.0 with 88,000+ ticket type records
Migration now completes successfully without SQL errors
Legacy ticket data is correctly migrated to the new structure